### PR TITLE
Correct Giter8 parameter example

### DIFF
--- a/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/06-sbt-new-and-Templates.md
+++ b/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/06-sbt-new-and-Templates.md
@@ -63,7 +63,7 @@ For more, see [Giter8 templates](https://github.com/foundweekends/giter8/wiki/gi
 You can append Giter8 parameters to the end of the command, so for example to specify a particular branch you can use:
 
 ```
-\$ sbt new scala/scala-seed.g8 --branch myBranch
+\$ sbt new scala/scala-seed.g8 --branch=myBranch
 ```
 
 #### How to create a Giter8 template


### PR DESCRIPTION
The documentation incorrectly uses a space character to separate the Giter8 parameter name from its value, instead of an `=`.

This can be verified using the scala-seed template:

```bash
$ sbt new scala/scala-seed.g8 --name test
[info] welcome to sbt 1.3.13 (AdoptOpenJdk Java 1.8.0_202)
[info] loading global plugins from /Users/me/.sbt/1.0/plugins
[info] set current project to tmp (in build file:/tmp/)
[info] set current project to tmp (in build file:/tmp/)
Error: Unknown option --name
Error: Unknown argument 'test'
Try --help for more information.
```

vs

```bash
$ sbt new scala/scala-seed.g8 --name=test2
[info] welcome to sbt 1.3.13 (AdoptOpenJdk Java 1.8.0_202)
[info] loading global plugins from /Users/me/.sbt/1.0/plugins
[info] set current project to tmp (in build file:/tmp/)
[info] set current project to tmp (in build file:/tmp/)

Template applied in /tmp/./test2
```
